### PR TITLE
Reapply field limits when parent is updated

### DIFF
--- a/src/field-limits/BoardPage/index.js
+++ b/src/field-limits/BoardPage/index.js
@@ -13,6 +13,7 @@ export default class FieldLimitsSettingsPage extends PageModification {
     swimlane: '.ghx-swimlane',
     column: '.ghx-column',
     ghxPool: '#ghx-pool',
+    ghxViewSelector: '#ghx-view-selector',
   };
 
   static classes = {
@@ -50,6 +51,11 @@ export default class FieldLimitsSettingsPage extends PageModification {
       childList: true,
       subtree: true,
     });
+
+    this.onDOMChange(FieldLimitsSettingsPage.jiraSelectors.ghxViewSelector, () => this.checkIfLimitsAreApplied(), {
+      childList: true,
+      subtree: true,
+    });
   }
 
   applyLimits() {
@@ -69,6 +75,13 @@ export default class FieldLimitsSettingsPage extends PageModification {
           issue.style.backgroundColor = COLORS.OVER_WIP_LIMITS;
         });
     });
+  }
+
+  checkIfLimitsAreApplied() {
+    if (!document.body.contains(this.fieldLimitsList)) {
+      const limitsStats = this.getLimitsStats();
+      this.applyLimitsList(limitsStats);
+    }
   }
 
   applyLimitsList(limitsStats) {


### PR DESCRIPTION
For some reason when quick filters are aplied or some update are taken for some reason the limits are refreshed and imediately dissapear...

This problem is not appear all the times and nor for all boards, only for once that are a lot of cards and people working on.

Before:

![Screen-Recording-2022-09-16-at-15 33 56](https://user-images.githubusercontent.com/13546351/190708460-7637034b-958e-4e76-8fb2-e31beb29b049.gif)

My code is nice? No.
There are better choices to solve this problem? Of course.

But I have no idea to solve it better... I'm accepting suggestions.